### PR TITLE
refactor: use a separate `Color` struct instead of type alias to `Vector`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,28 @@
-use crate::vector::Vector;
+use std::ops;
 
-pub type Color = Vector<f64, 3>;
+#[derive(Clone)]
+pub struct Color {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+impl Color {
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        Color { r, g, b }
+    }
+}
+
+impl ops::Mul<u8> for Color {
+    type Output = Color;
+    fn mul(self, rhs: u8) -> Self::Output {
+        Color::new(self.r * rhs, self.g * rhs, self.b * rhs)
+    }
+}
+
+impl ops::Add<u8> for Color {
+    type Output = Color;
+    fn add(self, rhs: u8) -> Self::Output {
+        Color::new(self.r + rhs, self.g + rhs, self.b + rhs)
+    }
+}


### PR DESCRIPTION
Conflicts include overlapping implementations for `Display`/`Debug`. PPM P3 needs a specific format, necessitating this separate struct.